### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,8 @@
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/6](https://github.com/PatrykPatryk5/node-soundcloud-downloader/security/code-scanning/6)

To fix the problem, add a `permissions` block in the workflow to explicitly limit the permissions of the `GITHUB_TOKEN` to the minimum required. In this context, a `permissions: contents: read` block at the workflow root (near the top, before `jobs:`) suffices. This ensures all jobs inherit these restrictions unless overridden. Only the `.github/workflows/node.js.yml` file is affected, with the change being an inserted YAML section.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
